### PR TITLE
Delete .vscode/Bookmark.bcat

### DIFF
--- a/.vscode/Bookmark.bcat
+++ b/.vscode/Bookmark.bcat
@@ -1,1 +1,0 @@
-[{"Group":"This is a sample~","Time":"","FileAndPath":[{"Tag":"Welcome use bookmark","Path":"","Start":"0.0","End":"0.0","Time":""}]}]


### PR DESCRIPTION
Se eliminó una configuración de extensión usada para trabajar en la issue de ResultadoUsoItem